### PR TITLE
Check kernel parameters safely

### DIFF
--- a/init/onboot_script
+++ b/init/onboot_script
@@ -48,8 +48,8 @@ if grep -q onboot_script_url= /proc/cmdline; then
   url_param=$(grep -o 'onboot_script_url=\S*' /proc/cmdline)
   url=${url_param#onboot_script_url=}
 
-  if has_param payload;then
-    payload="payload=$(get_param payload)"
+  if has_param 'payload';then
+    payload="payload=$(get_param 'payload')"
   fi
 
   curl "${url}?${payload}" > /onboot_script

--- a/init/onboot_script
+++ b/init/onboot_script
@@ -2,6 +2,23 @@
 set -e
 set -x
 
+has_param()
+{
+  param=$1
+  set +e
+  grep -q -o "${param}\S*" /proc/cmdline
+  rc=$?
+  set -e
+  return "${rc}"
+}
+
+get_param()
+{
+  param_name=$1
+  param_id=$(grep -o "${param_name}=\S*" /proc/cmdline)
+  echo "${param_id#${param_name}=}"
+}
+
 wait_network()
 {
   MAX_RETRIES=20
@@ -31,9 +48,8 @@ if grep -q onboot_script_url= /proc/cmdline; then
   url_param=$(grep -o 'onboot_script_url=\S*' /proc/cmdline)
   url=${url_param#onboot_script_url=}
 
-  payload=$(grep -o 'payload=\S*' /proc/cmdline)
-  if [ -z  "${payload#payload=}" ];then
-    payload=""
+  if has_param payload;then
+    payload="payload=$(get_param payload)"
   fi
 
   curl "${url}?${payload}" > /onboot_script


### PR DESCRIPTION
@dturn presently any script that has no payload parameter will fail to run, because the onboot_script bails out due to the "no errors" flag.

I have copied in two library functions "check param" and "get param", but otherwise preserved the logic.

They key difference is that "check param" checks for the presence of a kernel parameter in a context that allows errors.
