### PR TITLE
Xenial support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ ADD init/timed_shutdown /usr/local/bin/timed_shutdown
 RUN chmod +x /usr/local/bin/timed_shutdown
 RUN systemctl enable timed_shutdown
 
-# Enable ttyS1 getty for serial console
-RUN systemctl enable getty@ttyS1
-
 # Don't invoke rc.d policy scripts
 ADD util/rc.d-policy-stub /usr/sbin/policy-rc.d
 RUN chmod +x /usr/sbin/policy-rc.d
@@ -49,6 +46,8 @@ RUN apt-get install -y \
   openssh-server \
   smartmontools \
   mysql-common \
+  ubuntu-standard \
+  sudo \
   vim \
   wget \
   xfsprogs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM dalehamel/ubuntu-docker-upstart-minimal
+FROM dalehamel/ubuntu-docker-systemd-minimal
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ADD etc/ttyS1.conf /etc/init/ttyS1.conf
-ADD init/onboot_script.conf /etc/init/onboot_script.conf
+# Install systemd unit files
+ADD init/onboot_script.service /etc/systemd/system/onboot_script.service
 ADD init/onboot_script /usr/local/bin/onboot_script
-
 RUN chmod +x /usr/local/bin/onboot_script
+RUN systemctl enable onboot_script
 
-ADD init/shutdown.conf /etc/init/shutdown.conf
+
+ADD init/timed_shutdown.service /etc/systemd/system/timed_shutdown.service
 ADD init/timed_shutdown /usr/local/bin/timed_shutdown
-
 RUN chmod +x /usr/local/bin/timed_shutdown
+RUN systemctl enable timed_shutdown
 
-# Divert initctl temporarily so apt-update can work
-RUN dpkg-divert --local --rename --add /sbin/initctl
-RUN ln -s /bin/true /sbin/initctl
+# Enable ttyS1 getty for serial console
+RUN systemctl enable getty@ttyS1
 
 # Don't invoke rc.d policy scripts
 ADD util/rc.d-policy-stub /usr/sbin/policy-rc.d
@@ -26,16 +26,15 @@ RUN chmod +x /usr/sbin/policy-rc.d
 RUN apt-get update
 
 # Get ruby
-RUN  echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main" >> /etc/apt/sources.list
+RUN  echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu xenial main" >> /etc/apt/sources.list
 RUN gpg --keyserver keyserver.ubuntu.com --recv C3173AA6
 RUN apt-get update
 RUN apt-get install -y --force-yes ruby2.3 ruby-switch
-RUN ruby-switch --set ruby2.3
 
 # Get megacli
 RUN curl http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key -o /tmp/megaraid_gpg
 RUN apt-key add /tmp/megaraid_gpg
-RUN echo 'deb http://hwraid.le-vert.net/ubuntu trusty main' >> /etc/apt/sources.list
+RUN echo 'deb http://hwraid.le-vert.net/ubuntu wily main' >> /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y --force-yes megacli
 
@@ -46,13 +45,17 @@ RUN apt-get install -y \
   lldpd \
   lvm2 \
   mdadm \
+  net-tools \
   openssh-server \
   smartmontools \
+  mysql-common \
   vim \
   wget \
   xfsprogs \
   xz-utils
 
+RUN wget http://launchpadlibrarian.net/212189159/libmysqlclient18_5.6.25-0ubuntu1_amd64.deb
+RUN dpkg -i libmysqlclient18_5.6.25-0ubuntu1_amd64.deb
 ADD sysbench /usr/bin/sysbench
 
 RUN chmod +x /usr/bin/sysbench
@@ -66,7 +69,6 @@ RUN mv /tmp/mprime /usr/bin
 RUN apt-get install -y \
   cpuburn \
   fio \
-  libmysqlclient18 \
   stress \
   stressapptest
 
@@ -83,10 +85,6 @@ RUN useradd -G sudo -m ubuntu
 RUN echo ubuntu:ubuntu | chpasswd
 ADD etc/sudoers /etc/sudoers
 
-# Undo the diversion so upstart can work
-RUN rm /sbin/initctl
-RUN dpkg-divert --local --rename --remove /sbin/initctl
-
 # Undo the fake policy-rc.d
 RUN rm /usr/sbin/policy-rc.d
 
@@ -94,8 +92,4 @@ RUN rm /usr/sbin/policy-rc.d
 RUN rm -rf /var/lib/apt/lists/*
 # this forces "apt-get update" in dependent images, which is also good
 
-# Get rid of this, we don't need it anymore and it'll mess with the real init
-RUN rm /etc/init/fake-container-events.conf
-
 CMD ["/sbin/init"]
-

--- a/init/onboot_script.conf
+++ b/init/onboot_script.conf
@@ -1,5 +1,0 @@
-start on (started networking)
-
-script
-  /usr/local/bin/onboot_script
-end script

--- a/init/onboot_script.service
+++ b/init/onboot_script.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run an arbitrary script on boot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/onboot_script
+
+[Install]
+WantedBy=multi-user.target

--- a/init/shutdown.conf
+++ b/init/shutdown.conf
@@ -1,5 +1,0 @@
-start on startup
-
-script
-  /usr/local/bin/timed_shutdown
-end script

--- a/init/timed_shutdown.service
+++ b/init/timed_shutdown.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Shut the system down after a specified amount of time
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/timed_shutdown
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Why

As we transition to ubuntu 16.04, we should make sure that it actually works on our servers. This image is based on the same image that our linecook images are, so it helps us validate that the underlying base image is indeed valid.

Also, as 16.04 moves to systemd, we should eleminate the upstart scripts from our live image, which relied heavily on upstart. 

# How

This uses ubuntu-docker-systemd-minimal as a base instead of the upstart counterpart. The upstart scripts have been replaced with systemd unit files.

Notably, we no longer need an explicit ttyS1 service, as systemd seems to be smart enough to detect the presence of the ttyS1 serial console and spawn a getty all on its own. I tried explicitly registering a ttyS1 getty originall, and was pleasantly surprised to see it didn't work - there were two gettys listening on the same serial console. So, we don't need to care about serial consoles at all with systemd apparently, which is pretty great.

I made a few other compatibility changes for systemd here as well. Changed the PPA distros, and had to modify some dependencies.



@dwradcliffe @dturn 